### PR TITLE
Add installation guide retrieval and order filtering

### DIFF
--- a/Server/Controllers/EsimController.cs
+++ b/Server/Controllers/EsimController.cs
@@ -113,6 +113,18 @@ public class EsimController(
         return Ok(order);
     }
 
+    [HttpGet("my/installation/{iccid}")]
+    public async Task<IActionResult> GetInstallation(string iccid, [FromQuery] string lang, CancellationToken cancellationToken = default)
+    {
+        var session = await sessionResolver.GetSession(cancellationToken);
+        if (session == null)
+        {
+            return Unauthorized();
+        }
+        var order = await eSimPackageService.GetInstallationGuide(iccid, lang.ConvertToLanguage(), session, cancellationToken);
+        return Ok(order);
+    }
+
     [HttpPost("order")]
     public async Task<IActionResult> MakeOrder([FromBody] CreateESimOrderView view, CancellationToken cancellationToken = default)
     {

--- a/Services/Features/ESimOrder/ESimOrderService.cs
+++ b/Services/Features/ESimOrder/ESimOrderService.cs
@@ -23,6 +23,15 @@ public class ESimOrderService(
 
         Sorting(ref esimOrder, options);
 
+        if (options.EsimIsActive == true)
+        {
+            esimOrder = esimOrder.Where(x => x.ActivationDate != null && x.ActivationDate <= DateTime.UtcNow.AddDays(x.Validity));
+        }
+        else if (options.EsimIsActive == false)
+        {
+            esimOrder = esimOrder.Where(x => x.ActivationDate == null || x.ActivationDate > DateTime.UtcNow.AddDays(x.Validity));
+        }
+
         var count = await esimOrder.AsNoTracking().CountAsync(cancellationToken: cancellationToken);
         var items = await esimOrder.AsNoTracking().Paginate(options).ToListAsync(cancellationToken: cancellationToken);
         return new TableResponse<ESimOrderView>() { Items = items.MapToViewList(), TotalItems = count };

--- a/Shared/Features/AirAlo/Package/IAiraloPackageService.cs
+++ b/Shared/Features/AirAlo/Package/IAiraloPackageService.cs
@@ -8,6 +8,9 @@ public interface IAiraloPackageService : IComputeService
     [ComputeMethod]
     Task<PackageResponseView> GetAllAsync(TableOptions options, string type, CancellationToken cancellationToken = default);
 
+    [ComputeMethod]
+    Task<object> GetInstallationGuide(string iccid, Language language, CancellationToken cancellationToken = default);
+
     [ComputeMethod(AutoInvalidationDelay = 900)]
     Task<OrderPackageStatusView> GetOrderPackageStatusAsync(string iccid, CancellationToken cancellationToken = default);
 

--- a/Shared/Features/ESimOrder/ESimOrder.cs
+++ b/Shared/Features/ESimOrder/ESimOrder.cs
@@ -12,7 +12,7 @@ public class ESimOrderEntity : BaseEntity
     public string PackageId { get; set; } = string.Empty;
     public string Data { get; set; } = string.Empty;
     public float Price { get; set; }
-    public int Validity { get; set; } 
+    public int Validity { get; set; }
     #endregion
 
     #region Sim data

--- a/Shared/Features/ESimPackage/IEsimPackageService.cs
+++ b/Shared/Features/ESimPackage/IEsimPackageService.cs
@@ -23,6 +23,9 @@ public interface IESimPackageService : IComputeService
     [ComputeMethod]
     Task<UserView> GetUserAsync(long Id, CancellationToken cancellationToken = default);
 
+    [ComputeMethod]
+    Task<object> GetInstallationGuide(string iccid, Language language, Session session, CancellationToken cancellationToken = default);
+
     [CommandHandler]
     Task Create(CreateESimPackageCommand command, CancellationToken cancellationToken = default);
 

--- a/Shared/Infrastructure/Extensions/TableOptions.cs
+++ b/Shared/Infrastructure/Extensions/TableOptions.cs
@@ -19,6 +19,7 @@ public sealed partial record TableOptions
     [property: DataMember] public string? Search { get; set; }
     [property: DataMember] public string? CountrySlug { get; set; }
     [property: DataMember] public bool? HasVoicePack { get; set; }
+    [property: DataMember] public bool? EsimIsActive { get; set; }
 
     [property: DataMember] public DateOnly? From { get; set; }
 


### PR DESCRIPTION
- Implemented a new HTTP GET endpoint in `EsimController` for fetching installation guides using ICCID and language, with session validation.
- Added a method in `AiraloPackageService` to retrieve installation guides from an external API, including error handling for deserialization.
- Enhanced `ESimOrderService` to filter orders by activation status for better management of eSIM orders.
- Updated `ESimPackageService` to check user permissions when retrieving installation guides.
- Modified `IAiraloPackageService` and `IESimPackageService` interfaces to include the new `GetInstallationGuide` method.
- Introduced `EsimIsActive` property in `TableOptions` for filtering eSIM orders.
- Made minor formatting and structural improvements across various classes.