### PR TITLE
Enhance eSIM order filtering by activation status

### DIFF
--- a/Services/Features/ESimOrder/ESimOrderService.cs
+++ b/Services/Features/ESimOrder/ESimOrderService.cs
@@ -23,15 +23,6 @@ public class ESimOrderService(
 
         Sorting(ref esimOrder, options);
 
-        if (options.EsimIsActive == true)
-        {
-            esimOrder = esimOrder.Where(x => x.ActivationDate != null && x.ActivationDate <= DateTime.UtcNow.AddDays(x.Validity));
-        }
-        else if (options.EsimIsActive == false)
-        {
-            esimOrder = esimOrder.Where(x => x.ActivationDate == null || x.ActivationDate > DateTime.UtcNow.AddDays(x.Validity));
-        }
-
         var count = await esimOrder.AsNoTracking().CountAsync(cancellationToken: cancellationToken);
         var items = await esimOrder.AsNoTracking().Paginate(options).ToListAsync(cancellationToken: cancellationToken);
         return new TableResponse<ESimOrderView>() { Items = items.MapToViewList(), TotalItems = count };
@@ -67,6 +58,15 @@ public class ESimOrderService(
             var user = await userService.GetUserAsync(session, cancellationToken)
                 ?? throw new NotFoundException("User not found");
             esimOrder = esimOrder.Where(x => x.UserId == user.Id);
+        }
+
+        if (options.EsimIsActive == true)
+        {
+            esimOrder = esimOrder.Where(x => x.ActivationDate != null && x.ActivationDate <= DateTime.UtcNow.AddDays(x.Validity));
+        }
+        else if (options.EsimIsActive == false)
+        {
+            esimOrder = esimOrder.Where(x => x.ActivationDate == null || x.ActivationDate > DateTime.UtcNow.AddDays(x.Validity));
         }
 
         Sorting(ref esimOrder, options);


### PR DESCRIPTION
Updated the filtering logic in `ESimOrderService` to conditionally include records based on the `EsimIsActive` property. If `EsimIsActive` is true, only records with a valid `ActivationDate` are included; if false, records with a null or future `ActivationDate` are considered. This improves the accuracy of eSIM order retrieval based on active status.