### PR TITLE
Refactor installation guide methods to return JSON

### DIFF
--- a/Server/Controllers/EsimController.cs
+++ b/Server/Controllers/EsimController.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+
 namespace Server.Controllers;
 
 [Route("api/esim")]
@@ -122,7 +124,13 @@ public class EsimController(
             return Unauthorized();
         }
         var order = await eSimPackageService.GetInstallationGuide(iccid, lang.ConvertToLanguage(), session, cancellationToken);
-        return Ok(order);
+        //return string as json
+        return new ContentResult
+        {
+            Content = order,
+            ContentType = "application/json",
+            StatusCode = 200
+        };
     }
 
     [HttpPost("order")]

--- a/Services/Features/Airalo/Package/AiraloPackageService.cs
+++ b/Services/Features/Airalo/Package/AiraloPackageService.cs
@@ -58,7 +58,7 @@ public class AiraloPackageService(IServiceProvider services,
         return packages;
     }
 
-    public virtual async Task<object> GetInstallationGuide(string iccid, Language language, CancellationToken cancellationToken = default)
+    public virtual async Task<string> GetInstallationGuide(string iccid, Language language, CancellationToken cancellationToken = default)
     {
         await Invalidate();
         string url = $"{configuration["Airalo:Host"]}/v2/sims/{iccid}/instructions";
@@ -68,11 +68,7 @@ public class AiraloPackageService(IServiceProvider services,
         httpClient.DefaultRequestHeaders.Add("Accept-Language", language.ToString().ToLowerInvariant());
         var response = await httpClient.GetAsync(url, cancellationToken);
         response.EnsureSuccessStatusCode();
-        var content = await response.Content.ReadAsStringAsync(cancellationToken);
-        var packages = JsonConvert.DeserializeObject<object>(content, jsonSerializerSettings)
-            ?? throw new BadRequestException("Failed to deserialize package response.");
-
-        return packages;
+        return await response.Content.ReadAsStringAsync(cancellationToken);
     }
 
     public virtual async Task<OrderPackageStatusView> GetOrderPackageStatusAsync(string iccid, CancellationToken cancellationToken = default)

--- a/Services/Features/ESimPackage/ESimPackageService.cs
+++ b/Services/Features/ESimPackage/ESimPackageService.cs
@@ -241,7 +241,7 @@ public class ESimPackageService(
         return userView;
     }
 
-    public virtual async Task<object> GetInstallationGuide(string iccid, Language language, Session session, CancellationToken cancellationToken = default)
+    public virtual async Task<string> GetInstallationGuide(string iccid, Language language, Session session, CancellationToken cancellationToken = default)
     {
         await Invalidate();
         await using var dbContext = await DbHub.CreateDbContext(cancellationToken);

--- a/Shared/Features/AirAlo/Package/IAiraloPackageService.cs
+++ b/Shared/Features/AirAlo/Package/IAiraloPackageService.cs
@@ -9,7 +9,7 @@ public interface IAiraloPackageService : IComputeService
     Task<PackageResponseView> GetAllAsync(TableOptions options, string type, CancellationToken cancellationToken = default);
 
     [ComputeMethod]
-    Task<object> GetInstallationGuide(string iccid, Language language, CancellationToken cancellationToken = default);
+    Task<string> GetInstallationGuide(string iccid, Language language, CancellationToken cancellationToken = default);
 
     [ComputeMethod(AutoInvalidationDelay = 900)]
     Task<OrderPackageStatusView> GetOrderPackageStatusAsync(string iccid, CancellationToken cancellationToken = default);

--- a/Shared/Features/ESimPackage/IEsimPackageService.cs
+++ b/Shared/Features/ESimPackage/IEsimPackageService.cs
@@ -24,7 +24,7 @@ public interface IESimPackageService : IComputeService
     Task<UserView> GetUserAsync(long Id, CancellationToken cancellationToken = default);
 
     [ComputeMethod]
-    Task<object> GetInstallationGuide(string iccid, Language language, Session session, CancellationToken cancellationToken = default);
+    Task<string> GetInstallationGuide(string iccid, Language language, Session session, CancellationToken cancellationToken = default);
 
     [CommandHandler]
     Task Create(CreateESimPackageCommand command, CancellationToken cancellationToken = default);


### PR DESCRIPTION
Updated `GetInstallationGuide` methods across multiple files to return JSON strings instead of objects.
- Added `System.Text.Json` namespace in `EsimController.cs`.
- Changed return type from `Task<object>` to `Task<string>` in `AiraloPackageService.cs` and `ESimPackageService.cs`.
- Updated interfaces `IAiraloPackageService.cs` and `IESimPackageService.cs` to reflect the new return type. These changes enhance API clarity and consistency.