### PR TITLE
Add eSIM navigation and localize dialog messages

### DIFF
--- a/Client/Core/Layout/NavMenu.razor
+++ b/Client/Core/Layout/NavMenu.razor
@@ -5,12 +5,14 @@
 <MudNavLink Href="/" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Home" IconColor="Color.Inherit"> @L["Home"]</MudNavLink>
 <MudNavLink Href="/categories" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Category" IconColor="Color.Inherit">@L["Category"]</MudNavLink>
 <MudNavLink Href="/merchantcategories" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Sell" IconColor="Color.Inherit">@L["Merchants"]</MudNavLink>
-<MudNavLink Href="/app-users" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Group" IconColor="Color.Inherit">@L["AppUsers"]</MudNavLink>
+<MudNavGroup Title="eSIM" Expanded="false" Icon="@Icons.Material.Filled.Dataset">
+    <MudNavLink Href="/esim-packages" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.SimCard" IconColor="Color.Inherit">@L["ESimPackages"]</MudNavLink>
+    <MudNavLink Href="/app-users" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Group" IconColor="Color.Inherit">@L["AppUsers"]</MudNavLink>
+</MudNavGroup>
 <MudNavGroup Title=@L["Settings"] Expanded="false" Icon="@Icons.Material.Filled.Settings">
     <MudNavLink Href="/facilities" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Tag" IconColor="Color.Inherit">@L["Facility"]</MudNavLink>
     <MudNavLink Href="/favorites" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Favorite" IconColor="Color.Inherit">@L["Favorite"]</MudNavLink>
     <MudNavLink Href="/files" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Attachment" IconColor="Color.Inherit">@L["File"]</MudNavLink>
-    <MudNavLink Href="/esim-packages" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.SimCard" IconColor="Color.Inherit">@L["ESimPackages"]</MudNavLink>
     <MudNavLink Href="/languages" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Language" IconColor="Color.Inherit">@L["Language"]</MudNavLink>
     <MudNavLink Href="/reviews" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Reviews" IconColor="Color.Inherit">@L["Review"]</MudNavLink>
     @if (Claims.Any(x => x.Type == ClaimTypes.Role && x.Value == "Admin"))

--- a/Client/Pages/ESimPackage/DiscountDialog.razor
+++ b/Client/Pages/ESimPackage/DiscountDialog.razor
@@ -1,7 +1,7 @@
 <MudDialog>
     <DialogContent>
         <div class="pa-4">
-            <MudText Typo="Typo.h6">Discount for @ESimPackageView.PackageId</MudText>
+            <MudText Typo="Typo.h6">@L["SetDiscountTitle"] @ESimPackageView.PackageId</MudText>
             <MudDivider />
             <MudNumericField @bind-Value="@ESimPackageView.CustomPrice"
                              Label="@L["PackagePrice"]"

--- a/Client/Pages/ESimPackage/DiscountDialog.razor.cs
+++ b/Client/Pages/ESimPackage/DiscountDialog.razor.cs
@@ -27,12 +27,12 @@ public partial class DiscountDialog
         var result = await Injector.Commander.Run(new UpdatePackageDiscountCommand(Injector.Session, ESimPackageView));
         if (!result.HasError)
         {
-            Injector.Snackbar.Add("Discount updated successfully", Severity.Success);
+            Injector.Snackbar.Add(L["DiscountUpdated"], Severity.Success);
             MudDialog!.Close(DialogResult.Ok(true));
         }
         else
         {
-            Injector.Snackbar.Add("Failed to update discount: " + result.Error?.Message, Severity.Error);
+            Injector.Snackbar.Add($"{L["FailedDiscountUpdate"]}: " + result.Error?.Message, Severity.Error);
         }
     }
 
@@ -42,7 +42,7 @@ public partial class DiscountDialog
     {
         if (discountPercentage < 0 || discountPercentage > 100)
         {
-            Injector.Snackbar.Add("Discount percentage must be between 0 and 100", Severity.Error);
+            Injector.Snackbar.Add(L["DiscountError1"], Severity.Error);
             return;
         }
 
@@ -54,7 +54,7 @@ public partial class DiscountDialog
     {
         if (discountPrice < 0 || discountPrice > ESimPackageView.CustomPrice)
         {
-            Injector.Snackbar.Add("Discount price must be between 0 and the original price", Severity.Error);
+            Injector.Snackbar.Add(L["DiscountError2"], Severity.Error);
             return;
         }
         PackageDiscountView.DiscountPrice = discountPrice;

--- a/Client/Pages/ESimPackage/SetProfitDialog.razor
+++ b/Client/Pages/ESimPackage/SetProfitDialog.razor
@@ -1,7 +1,7 @@
 <MudDialog>
     <DialogContent>
         <div class="pa-4">
-            <MudText Typo="Typo.h6">Set profit percentage for all packages</MudText>
+            <MudText Typo="Typo.h6">@L["SetProfitTitle"]</MudText>
             <MudDivider />
             <MudNumericField @bind-Value="@percent"
                              Label="@L["ProfitPercentage"]"

--- a/Client/Pages/ESimPackage/SetProfitDialog.razor.cs
+++ b/Client/Pages/ESimPackage/SetProfitDialog.razor.cs
@@ -18,7 +18,7 @@ public partial class SetProfitDialog
     {
         if (percent < 0 || percent > 100)
         {
-            Injector.Snackbar.Add("Profit percentage must be between 0 and 100", Severity.Error);
+            Injector.Snackbar.Add(L["ProfitEror1"], Severity.Error);
             return;
         }
         isLoading = true;
@@ -31,7 +31,7 @@ public partial class SetProfitDialog
         }
         else
         {
-            Injector.Snackbar.Add("Failed to update discount: " + countResult.Error?.Message, Severity.Error);
+            Injector.Snackbar.Add($"{L["ProfitError2"]}: " + countResult.Error?.Message, Severity.Error);
         }
 
         isLoading = false;

--- a/Services/Features/ESimPackage/ESimPackageService.cs
+++ b/Services/Features/ESimPackage/ESimPackageService.cs
@@ -131,7 +131,7 @@ public class ESimPackageService(
 
         var view = eSimPackage.MapToView();
         var currency = await currencyService.GetUsdCourse(cancellationToken);
-        double rate = double.Parse(currency.Rate);
+        double rate = double.Parse(currency.Rate.Split('.')[0]);
         view.Price = view.Price * rate;
         return view;
     }

--- a/Shared/Localization/SharedResource.Designer.cs
+++ b/Shared/Localization/SharedResource.Designer.cs
@@ -88,6 +88,15 @@ namespace Shared.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Activation policy.
+        /// </summary>
+        public static string ActivationPolicy {
+            get {
+                return ResourceManager.GetString("ActivationPolicy", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Active.
         /// </summary>
         public static string Active {
@@ -115,11 +124,29 @@ namespace Shared.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to App users.
+        /// </summary>
+        public static string AppUsers {
+            get {
+                return ResourceManager.GetString("AppUsers", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Average Check.
         /// </summary>
         public static string AverageCheck {
             get {
                 return ResourceManager.GetString("AverageCheck", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Balance.
+        /// </summary>
+        public static string Balance {
+            get {
+                return ResourceManager.GetString("Balance", resourceCulture);
             }
         }
         
@@ -304,6 +331,24 @@ namespace Shared.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Country Code.
+        /// </summary>
+        public static string CountryCode {
+            get {
+                return ResourceManager.GetString("CountryCode", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Country Name.
+        /// </summary>
+        public static string CountryName {
+            get {
+                return ResourceManager.GetString("CountryName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Create.
         /// </summary>
         public static string Create {
@@ -327,6 +372,24 @@ namespace Shared.Localization {
         public static string CurrentVersion {
             get {
                 return ResourceManager.GetString("CurrentVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Custom price.
+        /// </summary>
+        public static string CustomPrice {
+            get {
+                return ResourceManager.GetString("CustomPrice", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Data Volume.
+        /// </summary>
+        public static string DataVolume {
+            get {
+                return ResourceManager.GetString("DataVolume", resourceCulture);
             }
         }
         
@@ -376,6 +439,51 @@ namespace Shared.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Discount percentage must be between 0 and 100.
+        /// </summary>
+        public static string DiscountError1 {
+            get {
+                return ResourceManager.GetString("DiscountError1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Discount price must be between 0 and the original price.
+        /// </summary>
+        public static string DiscountError2 {
+            get {
+                return ResourceManager.GetString("DiscountError2", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Discount percentage.
+        /// </summary>
+        public static string DiscountPercentage {
+            get {
+                return ResourceManager.GetString("DiscountPercentage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Discount price.
+        /// </summary>
+        public static string DiscountPrice {
+            get {
+                return ResourceManager.GetString("DiscountPrice", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Discount updated successfully.
+        /// </summary>
+        public static string DiscountUpdated {
+            get {
+                return ResourceManager.GetString("DiscountUpdated", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Edit.
         /// </summary>
         public static string Edit {
@@ -403,6 +511,15 @@ namespace Shared.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to End date.
+        /// </summary>
+        public static string EndDate {
+            get {
+                return ResourceManager.GetString("EndDate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to EnterPrice.
         /// </summary>
         public static string EnterPrice {
@@ -421,6 +538,15 @@ namespace Shared.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to eSIM packages.
+        /// </summary>
+        public static string ESimPackages {
+            get {
+                return ResourceManager.GetString("ESimPackages", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Facilities.
         /// </summary>
         public static string Facilities {
@@ -435,6 +561,15 @@ namespace Shared.Localization {
         public static string Facility {
             get {
                 return ResourceManager.GetString("Facility", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to update discount.
+        /// </summary>
+        public static string FailedDiscountUpdate {
+            get {
+                return ResourceManager.GetString("FailedDiscountUpdate", resourceCulture);
             }
         }
         
@@ -471,6 +606,15 @@ namespace Shared.Localization {
         public static string files {
             get {
                 return ResourceManager.GetString("files", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Full Name.
+        /// </summary>
+        public static string FullName {
+            get {
+                return ResourceManager.GetString("FullName", resourceCulture);
             }
         }
         
@@ -700,6 +844,15 @@ namespace Shared.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Network.
+        /// </summary>
+        public static string Network {
+            get {
+                return ResourceManager.GetString("Network", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to No Images Found! Upload Your First Image.
         /// </summary>
         public static string NoImagesFound_UploadYourFirstImage {
@@ -732,6 +885,24 @@ namespace Shared.Localization {
         public static string OrganizationName {
             get {
                 return ResourceManager.GetString("OrganizationName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Package ID.
+        /// </summary>
+        public static string PackageId {
+            get {
+                return ResourceManager.GetString("PackageId", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Package price.
+        /// </summary>
+        public static string PackagePrice {
+            get {
+                return ResourceManager.GetString("PackagePrice", resourceCulture);
             }
         }
         
@@ -862,6 +1033,33 @@ namespace Shared.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Profit percentage must be between 0 and 100.
+        /// </summary>
+        public static string ProfitEror1 {
+            get {
+                return ResourceManager.GetString("ProfitEror1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to update profit.
+        /// </summary>
+        public static string ProfitEror2 {
+            get {
+                return ResourceManager.GetString("ProfitEror2", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Profit percentage.
+        /// </summary>
+        public static string ProfitPercentage {
+            get {
+                return ResourceManager.GetString("ProfitPercentage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Rating Average.
         /// </summary>
         public static string RatingAverage {
@@ -988,6 +1186,33 @@ namespace Shared.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Discount for.
+        /// </summary>
+        public static string SetDiscountTitle {
+            get {
+                return ResourceManager.GetString("SetDiscountTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Set profit.
+        /// </summary>
+        public static string SetProfit {
+            get {
+                return ResourceManager.GetString("SetProfit", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Set profit percentage for all packages.
+        /// </summary>
+        public static string SetProfitTitle {
+            get {
+                return ResourceManager.GetString("SetProfitTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Settings.
         /// </summary>
         public static string Settings {
@@ -1011,6 +1236,15 @@ namespace Shared.Localization {
         public static string SmsNotificationNumberRequired {
             get {
                 return ResourceManager.GetString("SmsNotificationNumberRequired", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Start date.
+        /// </summary>
+        public static string StartDate {
+            get {
+                return ResourceManager.GetString("StartDate", resourceCulture);
             }
         }
         
@@ -1042,11 +1276,47 @@ namespace Shared.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Profit updated successfully.
+        /// </summary>
+        public static string SuccessSetProfit {
+            get {
+                return ResourceManager.GetString("SuccessSetProfit", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Successfully updated.
         /// </summary>
         public static string SuccessUpdate {
             get {
                 return ResourceManager.GetString("SuccessUpdate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Sync packages.
+        /// </summary>
+        public static string SyncPackages {
+            get {
+                return ResourceManager.GetString("SyncPackages", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Sync packages failed.
+        /// </summary>
+        public static string SyncPackagesFailed {
+            get {
+                return ResourceManager.GetString("SyncPackagesFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Sync packages started in background.
+        /// </summary>
+        public static string SyncPackagesStarted {
+            get {
+                return ResourceManager.GetString("SyncPackagesStarted", resourceCulture);
             }
         }
         
@@ -1069,6 +1339,33 @@ namespace Shared.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Total countries.
+        /// </summary>
+        public static string TotalCountries {
+            get {
+                return ResourceManager.GetString("TotalCountries", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Total packages.
+        /// </summary>
+        public static string TotalPackages {
+            get {
+                return ResourceManager.GetString("TotalPackages", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Total users.
+        /// </summary>
+        public static string TotalUsers {
+            get {
+                return ResourceManager.GetString("TotalUsers", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Deleting can not be undone!.
         /// </summary>
         public static string UnDoneDelete {
@@ -1087,6 +1384,15 @@ namespace Shared.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to User details.
+        /// </summary>
+        public static string UserDetails {
+            get {
+                return ResourceManager.GetString("UserDetails", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to UserName.
         /// </summary>
         public static string UserName {
@@ -1096,11 +1402,29 @@ namespace Shared.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to User orders.
+        /// </summary>
+        public static string UserOrders {
+            get {
+                return ResourceManager.GetString("UserOrders", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to users.
         /// </summary>
         public static string users {
             get {
                 return ResourceManager.GetString("users", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Valid days.
+        /// </summary>
+        public static string ValidDays {
+            get {
+                return ResourceManager.GetString("ValidDays", resourceCulture);
             }
         }
         

--- a/Shared/Localization/SharedResource.resx
+++ b/Shared/Localization/SharedResource.resx
@@ -480,4 +480,113 @@
   <data name="NumberFormatForGlobalPay" xml:space="preserve">
     <value>The phone number must be in the format 998XXXXXXXXX (e.g. 998997961883)</value>
   </data>
+  <data name="ESimPackages" xml:space="preserve">
+    <value>eSIM packages</value>
+  </data>
+  <data name="AppUsers" xml:space="preserve">
+    <value>App users</value>
+  </data>
+  <data name="PackageId" xml:space="preserve">
+    <value>Package ID</value>
+  </data>
+  <data name="CountryCode" xml:space="preserve">
+    <value>Country Code</value>
+  </data>
+  <data name="CountryName" xml:space="preserve">
+    <value>Country Name</value>
+  </data>
+  <data name="DataVolume" xml:space="preserve">
+    <value>Data Volume</value>
+  </data>
+  <data name="ValidDays" xml:space="preserve">
+    <value>Valid days</value>
+  </data>
+  <data name="Network" xml:space="preserve">
+    <value>Network</value>
+  </data>
+  <data name="ActivationPolicy" xml:space="preserve">
+    <value>Activation policy</value>
+  </data>
+  <data name="CustomPrice" xml:space="preserve">
+    <value>Custom price</value>
+  </data>
+  <data name="DiscountPrice" xml:space="preserve">
+    <value>Discount price</value>
+  </data>
+  <data name="PackagePrice" xml:space="preserve">
+    <value>Package price</value>
+  </data>
+  <data name="DiscountPercentage" xml:space="preserve">
+    <value>Discount percentage</value>
+  </data>
+  <data name="StartDate" xml:space="preserve">
+    <value>Start date</value>
+  </data>
+  <data name="EndDate" xml:space="preserve">
+    <value>End date</value>
+  </data>
+  <data name="ProfitPercentage" xml:space="preserve">
+    <value>Profit percentage</value>
+  </data>
+  <data name="UserDetails" xml:space="preserve">
+    <value>User details</value>
+  </data>
+  <data name="Balance" xml:space="preserve">
+    <value>Balance</value>
+  </data>
+  <data name="SyncPackages" xml:space="preserve">
+    <value>Sync packages</value>
+  </data>
+  <data name="SetProfit" xml:space="preserve">
+    <value>Set profit</value>
+  </data>
+  <data name="TotalUsers" xml:space="preserve">
+    <value>Total users</value>
+  </data>
+  <data name="TotalPackages" xml:space="preserve">
+    <value>Total packages</value>
+  </data>
+  <data name="TotalCountries" xml:space="preserve">
+    <value>Total countries</value>
+  </data>
+  <data name="FullName" xml:space="preserve">
+    <value>Full Name</value>
+  </data>
+  <data name="SetProfitTitle" xml:space="preserve">
+    <value>Set profit percentage for all packages</value>
+  </data>
+  <data name="SetDiscountTitle" xml:space="preserve">
+    <value>Discount for</value>
+  </data>
+	
+  <data name="DiscountUpdated" xml:space="preserve">
+    <value>Discount updated successfully</value>
+  </data>
+  <data name="FailedDiscountUpdate" xml:space="preserve">
+    <value>Failed to update discount</value>
+  </data>
+  <data name="DiscountError1" xml:space="preserve">
+    <value>Discount percentage must be between 0 and 100</value>
+  </data>
+  <data name="DiscountError2" xml:space="preserve">
+    <value>Discount price must be between 0 and the original price</value>
+  </data>
+  <data name="ProfitEror1" xml:space="preserve">
+    <value>Profit percentage must be between 0 and 100</value>
+  </data>
+  <data name="ProfitEror2" xml:space="preserve">
+    <value>Failed to update profit</value>
+  </data>
+  <data name="SuccessSetProfit" xml:space="preserve">
+    <value>Profit updated successfully</value>
+  </data>
+  <data name="SyncPackagesFailed" xml:space="preserve">
+    <value>Sync packages failed</value>
+  </data>
+  <data name="SyncPackagesStarted" xml:space="preserve">
+    <value>Sync packages started in background</value>
+  </data>
+	<data name="UserOrders" xml:space="preserve">
+  <value>User orders</value>
+</data>
 </root>

--- a/Shared/Localization/SharedResource.ru-RU.resx
+++ b/Shared/Localization/SharedResource.ru-RU.resx
@@ -480,4 +480,112 @@
   <data name="SmsNotificationNumberRequired" xml:space="preserve">
     <value>Требуется номер уведомления SMS</value>
   </data>
+  <data name="ESimPackages" xml:space="preserve">
+  <value>Пакеты eSIM</value>
+</data>
+  <data name="AppUsers" xml:space="preserve">
+  <value>Пользователи приложения</value>
+</data>
+  <data name="PackageId" xml:space="preserve">
+  <value>ID пакета</value>
+</data>
+  <data name="CountryCode" xml:space="preserve">
+  <value>Код страны</value>
+</data>
+  <data name="CountryName" xml:space="preserve">
+  <value>Название страны</value>
+</data>
+  <data name="DataVolume" xml:space="preserve">
+  <value>Объем данных</value>
+</data>
+  <data name="ValidDays" xml:space="preserve">
+  <value>Срок действия (дни)</value>
+</data>
+  <data name="Network" xml:space="preserve">
+  <value>Сеть</value>
+</data>
+  <data name="ActivationPolicy" xml:space="preserve">
+  <value>Политика активации</value>
+</data>
+  <data name="CustomPrice" xml:space="preserve">
+  <value>Своя цена</value>
+</data>
+  <data name="DiscountPrice" xml:space="preserve">
+  <value>Цена со скидкой</value>
+</data>
+  <data name="PackagePrice" xml:space="preserve">
+  <value>Цена пакета</value>
+</data>
+  <data name="DiscountPercentage" xml:space="preserve">
+  <value>Процент скидки</value>
+</data>
+  <data name="StartDate" xml:space="preserve">
+  <value>Дата начала</value>
+</data>
+  <data name="EndDate" xml:space="preserve">
+  <value>Дата окончания</value>
+</data>
+  <data name="ProfitPercentage" xml:space="preserve">
+  <value>Процент прибыли</value>
+</data>
+  <data name="UserDetails" xml:space="preserve">
+  <value>Данные пользователя</value>
+</data>
+  <data name="Balance" xml:space="preserve">
+  <value>Баланс</value>
+</data>
+  <data name="SyncPackages" xml:space="preserve">
+  <value>Синхронизировать пакеты</value>
+</data>
+  <data name="SetProfit" xml:space="preserve">
+  <value>Установить прибыль</value>
+</data>
+  <data name="TotalUsers" xml:space="preserve">
+  <value>Всего пользователей</value>
+</data>
+  <data name="TotalPackages" xml:space="preserve">
+  <value>Всего пакетов</value>
+</data>
+  <data name="TotalCountries" xml:space="preserve">
+  <value>Всего стран</value>
+</data>
+  <data name="FullName" xml:space="preserve">
+  <value>Полное имя</value>
+</data>
+	<data name="SetProfitTitle" xml:space="preserve">
+  <value>Установить процент прибыли для всех пакетов</value>
+</data>
+	<data name="SetDiscountTitle" xml:space="preserve">
+  <value>Скидка для</value>
+</data>
+	<data name="DiscountUpdated" xml:space="preserve">
+  <value>Скидка успешно обновлена</value>
+</data>
+	<data name="FailedDiscountUpdate" xml:space="preserve">
+  <value>Не удалось обновить скидку</value>
+</data>
+	<data name="DiscountError1" xml:space="preserve">
+  <value>Процент скидки должен быть от 0 до 100</value>
+</data>
+	<data name="DiscountError2" xml:space="preserve">
+  <value>Цена со скидкой должна быть от 0 до исходной цены</value>
+</data>
+	<data name="ProfitEror1" xml:space="preserve">
+  <value>Процент прибыли должен быть от 0 до 100</value>
+</data>
+	<data name="ProfitEror2" xml:space="preserve">
+  <value>Не удалось обновить прибыль</value>
+</data>
+	<data name="SuccessSetProfit" xml:space="preserve">
+  <value>Прибыль успешно обновлена</value>
+</data>
+	<data name="SyncPackagesFailed" xml:space="preserve">
+  <value>Не удалось синхронизировать пакеты</value>
+</data>
+	<data name="SyncPackagesStarted" xml:space="preserve">
+  <value>Синхронизация пакетов запущена в фоновом режиме</value>
+</data>
+	<data name="UserOrders" xml:space="preserve">
+  <value>Заказы пользователя</value>
+</data>
 </root>

--- a/Shared/Localization/SharedResource.uz-Latn.resx
+++ b/Shared/Localization/SharedResource.uz-Latn.resx
@@ -480,4 +480,112 @@
   <data name="NumberFormatForGlobalPay" xml:space="preserve">
     <value>Telefon raqami 998xxxxxxxxxx formatida bo'lishi kerak (masalan 998997961838)</value>
   </data>
+  <data name="ESimPackages" xml:space="preserve">
+  <value>eSIM paketlari</value>
+</data>
+  <data name="AppUsers" xml:space="preserve">
+  <value>Ilova foydalanuvchilari</value>
+</data>
+  <data name="PackageId" xml:space="preserve">
+  <value>Paket ID</value>
+</data>
+  <data name="CountryCode" xml:space="preserve">
+  <value>Mamlakat kodi</value>
+</data>
+  <data name="CountryName" xml:space="preserve">
+  <value>Mamlakat nomi</value>
+</data>
+  <data name="DataVolume" xml:space="preserve">
+  <value>Ma’lumot hajmi</value>
+</data>
+  <data name="ValidDays" xml:space="preserve">
+  <value>Amal qilish muddati (kun)</value>
+</data>
+  <data name="Network" xml:space="preserve">
+  <value>Tarmoq</value>
+</data>
+  <data name="ActivationPolicy" xml:space="preserve">
+  <value>Faollashtirish siyosati</value>
+</data>
+  <data name="CustomPrice" xml:space="preserve">
+  <value>Maxsus narx</value>
+</data>
+  <data name="DiscountPrice" xml:space="preserve">
+  <value>Chegirmali narx</value>
+</data>
+  <data name="PackagePrice" xml:space="preserve">
+  <value>Paket narxi</value>
+</data>
+  <data name="DiscountPercentage" xml:space="preserve">
+  <value>Chegirma foizi</value>
+</data>
+  <data name="StartDate" xml:space="preserve">
+  <value>Boshlanish sanasi</value>
+</data>
+  <data name="EndDate" xml:space="preserve">
+  <value>Tugash sanasi</value>
+</data>
+  <data name="ProfitPercentage" xml:space="preserve">
+  <value>Foyda foizi</value>
+</data>
+  <data name="UserDetails" xml:space="preserve">
+  <value>Foydalanuvchi ma’lumotlari</value>
+</data>
+  <data name="Balance" xml:space="preserve">
+  <value>Balans</value>
+</data>
+  <data name="SyncPackages" xml:space="preserve">
+  <value>Paketlarni sinxronlash</value>
+</data>
+  <data name="SetProfit" xml:space="preserve">
+  <value>Foyda belgilash</value>
+</data>
+  <data name="TotalUsers" xml:space="preserve">
+  <value>Jami foydalanuvchilar</value>
+</data>
+  <data name="TotalPackages" xml:space="preserve">
+  <value>Jami paketlar</value>
+</data>
+  <data name="TotalCountries" xml:space="preserve">
+  <value>Jami mamlakatlar</value>
+</data>
+  <data name="FullName" xml:space="preserve">
+  <value>To‘liq ism</value>
+</data>
+	<data name="SetProfitTitle" xml:space="preserve">
+  <value>Barcha paketlar uchun foyda foizini belgilash</value>
+</data>
+	<data name="SetDiscountTitle" xml:space="preserve">
+  <value>Chegirma uchun</value>
+</data>
+	<data name="DiscountUpdated" xml:space="preserve">
+  <value>Chegirma muvaffaqiyatli yangilandi</value>
+</data>
+	<data name="FailedDiscountUpdate" xml:space="preserve">
+  <value>Chegirma yangilanishida xatolik yuz berdi</value>
+</data>
+	<data name="DiscountError1" xml:space="preserve">
+  <value>Chegirma foizi 0 va 100 oralig‘ida bo‘lishi kerak</value>
+</data>
+	<data name="DiscountError2" xml:space="preserve">
+  <value>Chegirma narxi 0 va asl narx oralig‘ida bo‘lishi kerak</value>
+</data>
+	<data name="ProfitEror1" xml:space="preserve">
+  <value>Foyda foizi 0 va 100 oralig‘ida bo‘lishi kerak</value>
+</data>
+	<data name="ProfitEror2" xml:space="preserve">
+  <value>Foyda yangilanishida xatolik yuz berdi</value>
+</data>
+	<data name="SuccessSetProfit" xml:space="preserve">
+  <value>Foyda muvaffaqiyatli yangilandi</value>
+</data>
+	<data name="SyncPackagesFailed" xml:space="preserve">
+  <value>Paketlarni sinxronlashda xatolik yuz berdi</value>
+</data>
+	<data name="SyncPackagesStarted" xml:space="preserve">
+  <value>Paketlarni sinxronlash orqa rejimda boshlandi</value>
+</data>
+	<data name="UserOrders" xml:space="preserve">
+  <value>Foydalanuvchi buyurtmalari</value>
+</data>
 </root>


### PR DESCRIPTION
- Updated `NavMenu.razor` to include a new "eSIM" group with links to "eSIM Packages" and "App Users".
- Changed titles and messages in `DiscountDialog.razor` and `DiscountDialog.razor.cs` to use localized strings.
- Modified `SetProfitDialog.razor` and its code-behind to utilize localized strings for titles and validation messages.
- Adjusted currency rate parsing in `ESimPackageService.cs`.
- Expanded `SharedResource.Designer.cs` with new localized strings for eSIM packages, discounts, and user details.
- Updated resource files (`SharedResource.resx`, `SharedResource.ru-RU.resx`, `SharedResource.uz-Latn.resx`) to include translations for new terms.